### PR TITLE
Finish porting script: shouldn't attempt action until after networking is up

### DIFF
--- a/ec2net.hotplug
+++ b/ec2net.hotplug
@@ -16,13 +16,11 @@
 # License.
 
 # During init and before the network service is started, metadata is not
-# available. Exit without attempting to configure the elastic interface.
-#if [ ! -f /var/lock/subsys/network ]; then
-#  exit
-#fi
-#if [ -f /dev/.in_sysinit ]; then
-#  exit
-#fi
+# available. Exit without attempting to configure the elastic interface
+# if eth0 isn't up yet.
+if [ ! -f /sys/class/net/eth0/operstate ] || ! grep 'up' /sys/class/net/eth0/operstate; then
+  exit
+fi
 
 . /etc/network/ec2net-functions
 


### PR DESCRIPTION
The script relies on having networking available to access the instance metadata service, and so the script can't run until networking is up. The original AWS script (in Amazon Linux) exits the hot plug script early if init hasn't finished or the networking service isn't up yet. That part of the script was commented out in this port, but not having it causes instances to (sometimes, because of a race condition I assume) fail to bring up the loopback interface if this script is installed prior to boot (e.g., in a baked AMI.)

I've updated the script to exit early if eth0 isn't up yet to solve this issue.