### PR TITLE
Fix: Del interface file when interface is removed

### DIFF
--- a/ec2net-functions
+++ b/ec2net-functions
@@ -214,6 +214,7 @@ plug_interface() {
 unplug_interface() {
   remove_rules
   remove_aliases
+  remove_primary
 }
 
 activate_primary() {


### PR DESCRIPTION
I created an EC2 instance with only one interface, and then automatically attached a secondary interface using ubuntu-ec2net. However, if I remove the interface, and then reboot the EC2 instance, I cannot connect any more to my EC2 instance.

It was due to the eth1.cfg file referencing an interface that was not there anymore. I added a line to automatically delete that file when the interface is removed while the instance is up.