### PR TITLE
Fix Bashisms in Bourne shell script

### DIFF
--- a/ec2net-functions
+++ b/ec2net-functions
@@ -173,11 +173,16 @@ rewrite_rules() {
   if [ "${INTERFACE}" == "eth0" ]; then
     return
   fi
-  ips=($(get_ipv4s))
-  if [ ${#ips[*]} -eq 0 ]; then
+  ips=$( get_ipv4s | xargs printf '%s ' )
+  if [ "${#ips}" -eq 0 ]; then
     remove_rules
     return
   fi
+# Could not figure out how to eliminate all these Bashisms but this script is
+# sourced from a /bin/sh script so we have to wrap them.
+bash -s -- "$RTABLE" $ips <<\EOF
+  RTABLE="$1" ; shift
+  ips=( "$@" )
   # Retrieve a list of IP rules for the route table that belongs
   # to this interface. Treat this as the stale list. For each IP
   # address obtained from metadata, cross the corresponding rule
@@ -185,22 +190,23 @@ rewrite_rules() {
   # outbound traffic from that IP to the interface route table.
   # Then, remove all other rules found in the stale list.
   declare -A rules
-  for rule in $(/sbin/ip rule list \
-                |grep "from .* lookup ${RTABLE}" \
-                |awk '{print $1$3}'); do
+  for rule in $( /sbin/ip rule list |
+                 grep "from .* lookup ${RTABLE}" |
+                 awk '{print $1$3}' ); do
     split=(${rule//:/ })
     rules[${split[1]}]=${split[0]}
   done
-  for ip in ${ips[@]}; do
+  for ip in "${ips[@]}"; do
     if [[ ${rules[${ip}]} ]]; then
       unset rules[${ip}]
     else
-      /sbin/ip rule add from ${ip} lookup ${RTABLE}
+      /sbin/ip rule add from "${ip}" lookup ${RTABLE}
     fi
   done
   for rule in "${!rules[@]}"; do
     /sbin/ip rule delete pref "${rules[${rule}]}"
   done
+EOF
 }
 
 plug_interface() {

--- a/ec2net-functions
+++ b/ec2net-functions
@@ -1,4 +1,4 @@
-# -*-Shell-script-*-
+#!/bin/sh
 
 # Copyright (C) 2012 Amazon.com, Inc. or its affiliates.
 # All Rights Reserved.

--- a/ec2net-functions
+++ b/ec2net-functions
@@ -33,8 +33,7 @@ fi
 export HWADDR
 
 # generate a routing table number
-RTABLE=${INTERFACE#eth}
-let RTABLE+=10000
+RTABLE=$(( ${INTERFACE#eth} + 10000 ))
 
 metadata_base="http://169.254.169.254/latest/meta-data/network/interfaces/macs"
 config_file="/etc/network/interfaces.d/${INTERFACE}.cfg"
@@ -43,7 +42,7 @@ dhclient_file="/etc/dhcp/dhclient-${INTERFACE}.conf"
 # make no changes to unmanaged interfaces
 if [ -s ${config_file} ]; then
   unmanaged=$(LANG=C grep -l "^[[:space:]]*EC2SYNC=no\([[:space:]#]\|$\)" $config_file)
-  if [ "${config_file}" == "${unmanaged}" ]; then
+  if [ "${config_file}" = "${unmanaged}" ]; then
     exit
   fi
 fi
@@ -74,13 +73,11 @@ get_ipv4s() {
 }
 
 get_primary_ipv4() {
-  ipv4s=($(get_ipv4s))
-  echo "${ipv4s[0]}"
+  printf '%s ' $(get_ipv4s) | cut -d' ' -f1
 }
 
 get_secondary_ipv4s() {
-  ipv4s=($(get_ipv4s))
-  echo "${ipv4s[@]:1}"
+  printf '%s ' $(get_ipv4s) | cut -d' ' -f2-
 }
 
 remove_primary() {
@@ -100,7 +97,7 @@ rewrite_primary() {
     return
   fi
   network=$(echo ${cidr}|cut -d/ -f1)
-  router=$(( $(echo ${network}|cut -d. -f4) + 1))
+  router=$(( $(echo ${network}|cut -d. -f4) + 1 ))
   gateway="$(echo ${network}|cut -d. -f1-3).${router}"
   cat <<- EOF > ${config_file}
 # This file is automaticatically generated

--- a/ec2net-functions
+++ b/ec2net-functions
@@ -81,7 +81,7 @@ get_secondary_ipv4s() {
 }
 
 remove_primary() {
-  if [ "${INTERFACE}" == "eth0" ]; then
+  if [ "${INTERFACE}" = "eth0" ]; then
     return
   fi
   rm -f ${config_file}
@@ -89,7 +89,7 @@ remove_primary() {
 }
 
 rewrite_primary() {
-  if [ "${INTERFACE}" == "eth0" ]; then
+  if [ "${INTERFACE}" = "eth0" ]; then
     return
   fi
   cidr=$(get_cidr)
@@ -159,7 +159,7 @@ rewrite_aliases() {
 }
 
 remove_rules() {
-  if [ "${INTERFACE}" == "eth0" ]; then
+  if [ "${INTERFACE}" = "eth0" ]; then
     return
   fi
   for rule in $(/sbin/ip rule list \
@@ -170,7 +170,7 @@ remove_rules() {
 }
 
 rewrite_rules() {
-  if [ "${INTERFACE}" == "eth0" ]; then
+  if [ "${INTERFACE}" = "eth0" ]; then
     return
   fi
   ips=$( get_ipv4s | xargs printf '%s ' )


### PR DESCRIPTION
Although this code base does seem to work on 16.04 to detect and provision new interfaces, I noticed several errors in the logs due to these "syntax errors".

The script as provided by Amazon is written with many Bashisms but it is sourced (not executed) from a Bourne shell script, `/sbin/dhclient-script`. This leads to many statements throwing errors and failing to execute and many conditionals always being falsey (non-zero).
